### PR TITLE
Fix bugs in "Watch our Agent play"

### DIFF
--- a/DQN/doom/Deep Q learning with Doom.ipynb
+++ b/DQN/doom/Deep Q learning with Doom.ipynb
@@ -892,7 +892,7 @@
     "        game.new_episode()\n",
     "        while not game.is_episode_finished():\n",
     "            frame = game.get_state().screen_buffer\n",
-    "            state = stack_frames(stacked_frames, frame)\n",
+    "            state, frames = stack_frames(stacked_frames, frame, True)\n",
     "            # Take the biggest Q value (= the best action)\n",
     "            Qs = sess.run(DQNetwork.output, feed_dict = {DQNetwork.inputs_: state.reshape((1, *state.shape))})\n",
     "            action = np.argmax(Qs)\n",

--- a/DQN/doom/Deep Q learning with Doom.ipynb
+++ b/DQN/doom/Deep Q learning with Doom.ipynb
@@ -887,7 +887,8 @@
     "    # Load the model\n",
     "    saver.restore(sess, \"./models/model.ckpt\")\n",
     "    game.init()\n",
-    "    for i in range(1):\n",
+    "    num_iters = 100\n",
+    "    for i in range(num_iters):\n",
     "        \n",
     "        game.new_episode()\n",
     "        while not game.is_episode_finished():\n",
@@ -901,7 +902,7 @@
     "            score = game.get_total_reward()\n",
     "        print(\"Score: \", score)\n",
     "        totalScore += score\n",
-    "    print(\"TOTAL_SCORE\", totalScore/100.0)\n",
+    "    print(\"TOTAL_SCORE\", totalScore/num_iters)\n",
     "    game.close()"
    ]
   }


### PR DESCRIPTION
The function "stack_frames" accepts three arguments, where only two are currently given. "True" is passed as the third argument to fix this bug. Furthermore, stack_frames returns two objects, and they are both being assigned to state currently. Fix is to separate into "state, frames = stack_frames()".