### PR TITLE
Update Q Learning with OpenAI Taxi-v3 video version.ipynb

### DIFF
--- a/Q learning/Taxi-v2/Q Learning with OpenAI Taxi-v2 video version.ipynb
+++ b/Q learning/Taxi-v2/Q Learning with OpenAI Taxi-v2 video version.ipynb
@@ -154,7 +154,7 @@
     }
    ],
    "source": [
-    "env = gym.make(\"Taxi-v2\")\n",
+    "env = gym.make(\"Taxi-v3\")\n",
     "env.render()"
    ]
   },


### PR DESCRIPTION
v2 ain't operational anymore (looks like it)