### PR TITLE
Update README for Frozen-lake Qlearning example.

### DIFF
--- a/Q learning/FrozenLake/readme.md
+++ b/Q learning/FrozenLake/readme.md
@@ -1,4 +1,4 @@
 # Two different versions
 
 - [Q* Learning with FrozenLake 🕹️⛄](https://github.com/simoninithomas/Deep_reinforcement_learning_Course/blob/master/Q%20learning/FrozenLake/Q%20Learning%20with%20FrozenLake.ipynb): use this version **if you want to follow the tutorial**
-- [Q* Learning with FrozenLake 🕹️⛄_unslippery](): Awesome Deterministic version (no slippery) made by [lukewys](https://github.com/simoninithomas/Deep_reinforcement_learning_Course/blob/master/Q%20learning/FrozenLake/Q%20Learning%20with%20FrozenLake_unslippery%20(Deterministic%20version).ipynb)
+- [Q* Learning with FrozenLake 🕹️⛄_unslippery](https://github.com/simoninithomas/Deep_reinforcement_learning_Course/blob/master/Q%20learning/FrozenLake/Q%20Learning%20with%20FrozenLake_unslippery%20(Deterministic%20version).ipynb): Awesome Deterministic version (no slippery) made by [lukewys](https://github.com/lukewys)


### PR DESCRIPTION
Issue: URL broken for deterministic version.

Fixes #79 